### PR TITLE
Refactor `quantify.outliers()`

### DIFF
--- a/OutlierDetectionAlgorithm/1.Outlier_Detection.R
+++ b/OutlierDetectionAlgorithm/1.Outlier_Detection.R
@@ -362,15 +362,14 @@ bic.trim.distribution <- NULL;
 # Use foreach to iterate over the rows of fpkm.tumor.symbol.filter in parallel
 bic.trim.distribution <- foreach(j = 1:nrow(fpkm.tumor.symbol.filter), .combine = rbind) %dopar% {
     sample.fpkm.qq <- round(as.numeric(fpkm.tumor.symbol.filter[j,patient.part]), digits = 6);
-    sample.trim.number <- trim.sample(sample.number, 0.05);
-    sample.fpkm.qq.sort <- sort(sample.fpkm.qq)[sample.trim.number];
-    sample.fpkm.qq.nozero <- sample.fpkm.qq.sort + add.minimum.value;
+    sample.fpkm.qq.trimmed <- trim.sample(sample.fpkm.qq, 0.05)
+    sample.fpkm.qq.trimmed.nozero <- sample.fpkm.qq.trimmed + add.minimum.value;
     
     
-    glm.norm <- gamlss(sample.fpkm.qq.nozero ~ 1, family=NO);
-    glm.lnorm <- gamlss(sample.fpkm.qq.nozero ~ 1, family=LNO);
-    glm.gamma <- gamlss(sample.fpkm.qq.nozero ~ 1, family=GA);
-    glm.exp <- gamlss(sample.fpkm.qq.nozero ~ 1, family=EXP);
+    glm.norm <- gamlss(sample.fpkm.qq.trimmed.nozero ~ 1, family=NO);
+    glm.lnorm <- gamlss(sample.fpkm.qq.trimmed.nozero ~ 1, family=LNO);
+    glm.gamma <- gamlss(sample.fpkm.qq.trimmed.nozero ~ 1, family=GA);
+    glm.exp <- gamlss(sample.fpkm.qq.trimmed.nozero ~ 1, family=EXP);
 
     glm.bic <- c(glm.norm$sbc,
                  glm.lnorm$sbc,


### PR DESCRIPTION
# Description

This includes refactoring for the script `1.Outlier_Detection.R`, mostly applied to the function `quantify.outliers`:

- Move definition of the `trim.sample` function closer to the top of the script, and remove a duplicate definition
- Remove extra calls to `as.numeric`
- Redefine the `trim` parameter to match that of `base::mean`
- Parameterize `nstart` for K-means clustering
- Place constants on left side of equality comparison operator throughout the script

Changes tested on `TCGA-ACC.htseq_fpkm.tsv`.