### PR TITLE
Refactor cosine similarity code

### DIFF
--- a/OutlierDetectionAlgorithm/1.Outlier_Detection.R
+++ b/OutlierDetectionAlgorithm/1.Outlier_Detection.R
@@ -379,14 +379,12 @@ bic.trim.distribution.fit <- apply(
 
 stopImplicitCluster();
 
-# Check the cosine similarity
-fpkm.tumor.symbol.filter.bic.fit <- cbind(fpkm.tumor.symbol.filter, distribution = bic.trim.distribution.fit);
 
 # run it parallel
 cl <- makeCluster(2);
 # register the cluster with the parallel package
 registerDoParallel(cl);
-clusterExport(cl, c('cosine.similarity.large.value.percent', 'outlier.detection.cosine');
+clusterExport(cl, c('cosine.similarity.large.value.percent', 'outlier.detection.cosine'));
 clusterEvalQ(cl, c(library(lsa), library(SnowballC)));
 
 data.cosine.bic.t <- lapply(
@@ -402,9 +400,9 @@ data.cosine.bic.t <- do.call(
     what = rbind,
     args = data.cosine.bic.t
     );
+data.cosine.bic.t <- as.data.frame(data.cosine.bic.t);
 rownames(data.cosine.bic.t) <- rownames(fpkm.tumor.symbol.filter);
 colnames(data.cosine.bic.t) <- c('cosine', 'distribution');
-
 
 stopImplicitCluster();
 


### PR DESCRIPTION
# Description

This includes refactoring for the script `1.Outlier_Detection.R` applied to the function `outlier.detection.cosine` and related code:

- Fix use of `trim.sample` in `outlier.detection.cosine` resulting from refactoring in previous pull request
- Encapsulate code for choosing the optimal distribution using BIC into the new function `identify.bic.optimal.distribution`
  - Simplify the code so that it only returns the numeric code representing the optimal distribution rather than the BIC value itself
  - Wrap calls to `gamlss` in `suppressWarnings`, and specify an argument in each call to avoid printing unnecessary output
- Move the definition of the function `cosine.similarity.large.value.percent` to the top level rather than being defined locally within the function `outlier.detection.cosine` to improve the readability
- Adjust definition of the function `outlier.detection.cosine`:
  - Add `distr`&mdash;the numeric code corresponding to the optimal distribution for the given data&mdash;as a parameter; this avoids having to append the code to the data itself as was done previously
- Simplify data processing within functions, and remove dependencies on global variables (e.g., `patient.part` or `sample.number`)