### PR TITLE
Replace hard-coded datafile name with envvar

### DIFF
--- a/Figure/README.md
+++ b/Figure/README.md
@@ -4,7 +4,7 @@ Most of the shared analysis code has been abstracted into an `outlierAnalysisSup
 
 Bootstrapping a new development environment requires the following steps:
 
-1. Set the environment variables `OUTLIER_DATA_DIR` and `OUTLIER_DATA_FILE` to reference the original outlier datafile. These can be set up in an `.Renviron` file as well.
+1. Set the environment variables `OUTLIER_DATA_DIR` and `OUTLIER_DATA_FILENAME` to reference the original outlier datafile. These can be set up in an `.Renviron` file as well.
 2. Within R, call `renv::restore()` to install all of the snapshotted packages.
 3. Within R, call `devtools::install('../outlierAnalysisSupport')` to install the helper package.
 

--- a/outlierAnalysisSupport/R/get.outlier.data.path.R
+++ b/outlierAnalysisSupport/R/get.outlier.data.path.R
@@ -6,7 +6,7 @@
 #' @return Full path to the outlier data file, suitable for 'attach'
 #' @export
 get.outlier.data.path <- function(data.dir = Sys.getenv('OUTLIER_DATA_DIR'),
-                                  data.file = '2024-10-08_Figure1_2_3_4_min_input.rda') {
+                                  data.file = Sys.getenv('OUTLIER_DATA_FILENAME')) {
     full.data.file <- file.path(data.dir, data.file);
 
     # Check if file exists before attaching


### PR DESCRIPTION
# Description
I missed this as part of #31. I tried to make the data loading process very generic and require that the user specify the data source via environment variables, either directly or with an `.Renviron` file:

```bash
OUTLIER_DATA_DIR='/Users/nwiltsie/src/project-CancerBiology-OutlierAnalysis/Figure/untracked_data/data'
OUTLIER_DATA_FILENAME='2024-10-08_Figure1_2_3_4_min_input.rda'
```

However, I forgot to implement the second environment variable! After this PR the raw datafile name should not be hard-coded anywhere.